### PR TITLE
config: Fix typo in link back to GitHub repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ wordless_logo: favicon.png
 search: false
 author: "Richard Littauer and Contributors"
 url: https://fossresponders.com
-github: https://github.com/foss-resonders/fossresponders.com
+github: https://github.com/foss-responders/fossresponders.com
 # Site owner
 owner:
   name: FOSS Responders


### PR DESCRIPTION
I tried to find the source for the site and got a 404. Small typo. :-)