### PR TITLE
index: Update Slack channel name to new name

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ COVID-19 is impacting the open source industry in many ways. If you or your comm
   </span>
 </a>
 
-Have something else you need? Please [open an issue](https://github.com/foss-responders/support-requests/issues/new) on GitHub or [join our Slack](https://slack.opencollective.com/#crisis-working-group). If you’d rather email than open a GitHub issue, please feel free to contact us at [foss-responders@googlegroups.com](mailto:foss-responders@googlegroups.com).
+Have something else you need? Please [open an issue](https://github.com/foss-responders/support-requests/issues/new) on GitHub or [join our Slack](https://slack.opencollective.com/#fossresponders). If you’d rather email than open a GitHub issue, please feel free to contact us at [foss-responders@googlegroups.com](mailto:foss-responders@googlegroups.com).
 
 ## We Can Give Help
 
@@ -61,7 +61,7 @@ What else should be here? [Get in touch](mailto:foss-responders@googlegroups.com
 
 ## About
 
-<p class="center"><a href="https://slack.opencollective.com/#crisis-working-group"><img src="https://img.shields.io/badge/slack-open%20collective-blue" alt="Slack link to Open Collective Slack"/></a> <a href="https://riot.im/app/#/room/#fossresponders:matrix.org"><img src="https://img.shields.io/badge/matrix-%23fossresponders--db%3Amatrix.org-blue.svg" alt="Connect to Matrix bridge" /></a></p>
+<p class="center"><a href="https://slack.opencollective.com/#fossresponders"><img src="https://img.shields.io/badge/slack-open%20collective-blue" alt="Slack link to Open Collective Slack"/></a> <a href="https://riot.im/app/#/room/#fossresponders:matrix.org"><img src="https://img.shields.io/badge/matrix-%23fossresponders--db%3Amatrix.org-blue.svg" alt="Connect to Matrix bridge" /></a></p>
 
 Open source software depends upon real-world interactions just as much as it does on code. With the alarming spread of the Coronavirus, the open source ecosystem is being affected in enormously impactful ways. This site is one of many efforts to help.
 


### PR DESCRIPTION
@piamancini updated the Slack channel name on Open Collective. This
updates the link on the website to point to the right place.