### PR TITLE
Add Drupal Association to list of organizations under Who We Are

### DIFF
--- a/index.md
+++ b/index.md
@@ -74,6 +74,7 @@ FOSS Responders is an open source, open project. Anyone can jump in and work on 
 Some of the companies where our volunteers work (but may or may not be representing their company) include:
 
 - [Aspiration](https://aspirationtech.org/)
+- [Drupal Association](https://www.drupal.org/association)
 - [GitLab](https://about.gitlab.com/)
 - [Indeed](https://indeed.com)
 - [Maintainer Mountaineer](https://maintainer.io)


### PR DESCRIPTION
The Drupal Association is currently missing from the Who We Are section - can we add it, please?