### PR TITLE
added links to logos

### DIFF
--- a/index.md
+++ b/index.md
@@ -184,28 +184,44 @@ search_omit: true
     <div class="col-lg-10">
       <div class="row justify-content-md-center">
         <div class="col-xs-4 col-sm-6 col-md-2">
+          <a href="https://aspiration.com" target="_blank">
           <img src="images/Layer 2.svg" alt="Aspiration">
+          </a>
         </div>
         <div class="col-xs-4 col-sm-6 col-md-3">
-          <img src="images/drupal-association-logo-rgb.png" alt="Drupal Association">
+           <a href="https://www.drupal.org/association" target="_blank">
+            <img src="images/drupal-association-logo-rgb.png" alt="Drupal Association">
+          </a>
         </div>
         <div class="col-xs-4 col-sm-6 col-md-3">
+           <a href="https://www.facebook.com/covidsupport" target="_blank">
           <img src="images/Image 7.png" alt="Facebook">
+          </a>
         </div>
         <div class="col-xs-4 col-sm-6 col-md-3">
+         <a href="https://www.gitlab.com" target="_blank">
           <img src="images/Image 3.png" alt="GitLab">
+          </a>
         </div>
         <div class="col-xs-4 col-sm-6 col-md-3">
+          <a href="https://www.indeed.com" target="_blank">
           <img src="images/Image 4.png" alt="Indeed">
+          </a>
         </div>
         <div class="col-xs-4 col-sm-6 col-md-3">
+          <a href="https://maintainer.io/" target="_blank">
           <img src="images/maintainer-io-logo.png" alt="Maintainer Mountaineer">
+          </a>
         </div>
         <div class="col-xs-4 col-sm-6 col-md-3">
+        <a href="https://opencollective.com/" target="_blank">
           <img src="images/Image 5.png" alt="Open Collective">
+          </a>
         </div>
         <div class="col-xs-4 col-sm-6 col-md-3">
+        <a href="https://redhat.com/" target="_blank">
           <img src="images/Image 6.png" alt="Red Hat">
+         </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
#56 
So for Facebook, I decided to link to their COVID-19 community help hub instead of just the main site. 

I just felt like linking to the main site wouldn't really catch, since everyone knows what Facebook is all about.

What do you think? I can easily change it to the main home page