### PR TITLE
Fixes github link in footer icons

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -41,7 +41,7 @@
 			<div>&copy; {{ site.time | date: '%Y' }} {{ site.owner.name }}. {% if page.pagename != 'privacy' %}<a href="/privacy">Privacy Policy</a>{% endif %}</div>
 			<div class="social-icons">
 				<a href="mailto:{{site.owner.email}}" title="Email us!" target="_blank" rel="noopener noreferrer"><img src="{{ site.url }}/images/envelope-square-solid.svg" /></a>
-				<a href="https://github.com/fossresponders/foss-responders" title="Improve this site on GitHub" target="_blank" rel="noopener noreferrer"><img src="{{ site.url }}/images/github-square-brands.svg" /></a>
+				<a href="https://github.com/foss-responders/fossresponders.com" title="Improve this site on GitHub" target="_blank" rel="noopener noreferrer"><img src="{{ site.url }}/images/github-square-brands.svg" /></a>
 				<a href="{{ site.url }}/feed.xml" title="Subscribe to the Atom/RSS feed"><img src="{{ site.url }}/images/rss-square-solid.svg" /></a>
 				<a href="https://slack.opencollective.com/#foss-responders" title="Join us on Slack" target="_blank" rel="noopener noreferrer"><img src="{{ site.url }}/images/slack-brands.svg" /></a>
 				<a href="https://fossresponders.discourse.group/" title="Join our Discourse" target="_blank" rel="noopener noreferrer"><img src="{{ site.url }}/images/discourse-brands.svg" /></a>


### PR DESCRIPTION
The github link used in the icon section in the footer of the website was wrong. This PR should fix it.