### PR TITLE
Fixes image ratio and adds link

### DIFF
--- a/_sass/_blog.scss
+++ b/_sass/_blog.scss
@@ -58,7 +58,9 @@
 
   .post-thumbnail-img {
     min-width: 180px;
-    max-width: 100%;
+    max-width: 250px;
+    height: auto;
+    width: 100%;
   }
 
   .post-thumbnail-info small {

--- a/blog/index.md
+++ b/blog/index.md
@@ -84,7 +84,9 @@ pagination:
               <img class="post-thumbnail-img" src="{{ post.image }}" />
             {% endif %}
             <div class="post-thumbnail-info">
-              <h3>{{ post.title }}</h3>
+              <a href="{{ post.url | relative_url }}">
+                <h3>{{ post.title }}</h3>
+              </a>
               <small>
                 Posted on <time datetime="{{ post.date | date_to_xmlschema }}">
                 {{ post.date | date: '%B %d, %Y' }}</time> by {{ author.name }}


### PR DESCRIPTION
Fixes #119 to some extent. It kind of makes the behaviour consistent over browsers (previously firefox was behaving okay but chrome was stretching image because of how they compute `height:auto` with `max-width`) and now there is no stretching. I still feel it might be worth discussing if we put evenly sized square images for the thumbnail. But this fix should make the images look non-stretched.

Also takes care of #120 to some extent. This PR adds the link to the actual blog. Right now the logic is such that apart from the two latest blog posts, every other blog post is shown in that area. Since there has only been 3 blog posts, it looks lonely and alone. A heading of some sort to denote this might be worth it. Like "Other Posts" or "More Posts" or something.